### PR TITLE
chore: update GitHub Action pins

### DIFF
--- a/.github/workflows/rust-workflow.yml
+++ b/.github/workflows/rust-workflow.yml
@@ -17,5 +17,5 @@ jobs:
       issues: write
       pull-requests: write
       contents: read
-    uses: famedly/backend-build-workflows/.github/workflows/rust-workflow.yml@v1
+    uses: famedly/backend-build-workflows/.github/workflows/rust-workflow.yml@fcc2ec82a725d5c4c9c6a8f19e8df101c178dcb6
     secrets: inherit

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -14,14 +14,14 @@ jobs:
       # To use this repository's private action, you must check out the repository
       - name: Get app token
         id: app_token
-        uses: famedly/Meow-GitHub-App-Auth@v0.1.0
+        uses: famedly/Meow-GitHub-App-Auth@3076fbaf849c50f5995cf9587cbe9a23bb0910e1
         with:
           app-id: ${{ vars.TEMPLATE_SYNC_APP_ID }}
           installation-id: ${{ vars.TEMPLATE_SYNC_INSTALLATION_ID }}
           key-base64: ${{ secrets.TEMPLATE_SYNC_APP_PK }}
           
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
         with:
           token: ${{ steps.app_token.outputs.GITHUB_APP_TOKEN }}
       - name: actions-template-sync

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           token: ${{ steps.app_token.outputs.GITHUB_APP_TOKEN }}
       - name: actions-template-sync
-        uses: AndreasAugustin/actions-template-sync@54cc6daa8773c61a6df312b2cb9f4f82ef72d690
+        uses: AndreasAugustin/actions-template-sync@8a0f668b83c32a0f673353086d74f12b8853d4f5
         with:
           github_token: ${{ steps.app_token.outputs.GITHUB_APP_TOKEN }}
           source_repo_path: famedly/rust-library-template


### PR DESCRIPTION
## Summary
- Update GitHub Actions in workflows to the latest upstream default-branch commit SHAs.
- Keep existing action paths and only replace refs after `@`.

## Verification
- Checked generated diff to include only `.github/**/*.yml` / `.github/**/*.yaml` workflow action refs.
- CI on this PR should validate the updated action versions.